### PR TITLE
[밑바닥부터 만드는 인터프리터 in Go] 토큰과 렉서 확장하기 3

### DIFF
--- a/밑바닥부터 만드는 인터프리터 in Go/src/monkey/lexer/lexer.go
+++ b/밑바닥부터 만드는 인터프리터 in Go/src/monkey/lexer/lexer.go
@@ -22,13 +22,27 @@ func (l *Lexer) NextToken() token.Token {
 
 	switch l.ch {
 	case '=':
-		tok = newToken(token.ASSIGN, l.ch)
+		if l.peekChar() == '=' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.EQ, Literal: literal}
+		} else {
+			tok = newToken(token.ASSIGN, l.ch)
+		}
 	case '+':
 		tok = newToken(token.PLUS, l.ch)
 	case '-':
 		tok = newToken(token.MINUS, l.ch)
 	case '!':
-		tok = newToken(token.BANG, l.ch)
+		if l.peekChar() == '=' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.NOT_EQ, Literal: literal}
+		} else {
+			tok = newToken(token.BANG, l.ch)
+		}
 	case '/':
 		tok = newToken(token.SLASH, l.ch)
 	case '*':
@@ -100,6 +114,13 @@ func (l *Lexer) readNumber() string {
 		l.readChar()
 	}
 	return l.input[position:l.position]
+}
+
+func (l *Lexer) peekChar() byte {
+	if l.readPosition >= len(l.input) {
+		return 0
+	}
+	return l.input[l.readPosition]
 }
 
 func newToken(tokenType token.TokenType, ch byte) token.Token {

--- a/밑바닥부터 만드는 인터프리터 in Go/src/monkey/lexer/lexer_test.go
+++ b/밑바닥부터 만드는 인터프리터 in Go/src/monkey/lexer/lexer_test.go
@@ -22,6 +22,9 @@ func TestNextToken(t *testing.T) {
 	} else {
 		return false;
 	}
+
+	10 == 10;
+	10 != 9;
 	`
 
 	tests := []struct {
@@ -93,6 +96,14 @@ func TestNextToken(t *testing.T) {
 		{token.FALSE, "false"},
 		{token.SEMICOLON, ";"},
 		{token.RBRACE, "}"},
+		{token.INT, "10"},
+		{token.EQ, "=="},
+		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+		{token.INT, "10"},
+		{token.NOT_EQ, "!="},
+		{token.INT, "9"},
+		{token.SEMICOLON, ";"},
 		{token.EOF, ""},
 	}
 

--- a/밑바닥부터 만드는 인터프리터 in Go/src/monkey/token/token.go
+++ b/밑바닥부터 만드는 인터프리터 in Go/src/monkey/token/token.go
@@ -26,6 +26,9 @@ const (
 	LT = "<"
 	GT = ">"
 
+	EQ     = "=="
+	NOT_EQ = "!="
+
 	// Delimiters
 	COMMA     = ","
 	SEMICOLON = ";"


### PR DESCRIPTION
### TL;DR

Added support for equality operators (`==` and `!=`) to the Monkey interpreter lexer.

### What changed?

- Implemented a new `peekChar()` method in the lexer to look ahead at the next character without consuming it
- Added handling for two-character tokens `==` and `!=` in the lexer's `NextToken()` method
- Added new token types `EQ` and `NOT_EQ` to represent equality operators
- Updated test cases to verify the new functionality

### How to test?

Run the lexer tests to verify that the lexer correctly tokenizes expressions containing equality operators:
```
go test ./src/monkey/lexer
```

The tests now include examples like `10 == 10` and `10 != 9` to verify the new operators work correctly.

### Why make this change?

Equality operators are essential for comparison operations in programming languages. Adding support for `==` and `!=` enhances the Monkey language's expressiveness, allowing for more complex conditional logic and boolean expressions in programs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - `==`(동등 연산자)와 `!=`(불일치 연산자) 토큰이 새롭게 인식됩니다.

- **버그 수정**
  - 동등 및 불일치 연산자에 대한 토큰 인식 테스트가 추가되어, 해당 연산자 처리의 정확성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->