### PR TITLE
[밑바닥부터 만드는 인터프리터 in Go] 표현식 파싱: 표현식 AST

### DIFF
--- a/밑바닥부터 만드는 인터프리터 in Go/src/monkey/ast/ast.go
+++ b/밑바닥부터 만드는 인터프리터 in Go/src/monkey/ast/ast.go
@@ -1,9 +1,13 @@
 package ast
 
-import "monkey/token"
+import (
+	"bytes"
+	"monkey/token"
+)
 
 type Node interface {
 	TokenLiteral() string
+	String() string
 }
 
 type Statement interface {
@@ -27,6 +31,16 @@ func (p *Program) TokenLiteral() string {
 	}
 }
 
+func (p *Program) String() string {
+	var out bytes.Buffer
+
+	for _, s := range p.Statements {
+		out.WriteString(s.String())
+	}
+
+	return out.String()
+}
+
 type LetStatement struct {
 	Token token.Token // token.LET token
 	Name  *Identifier
@@ -36,6 +50,22 @@ type LetStatement struct {
 func (ls *LetStatement) statementNode()       {}
 func (ls *LetStatement) TokenLiteral() string { return ls.Token.Literal }
 
+func (ls *LetStatement) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(ls.TokenLiteral() + " ")
+	out.WriteString(ls.Name.String())
+	out.WriteString(" = ")
+
+	if ls.Value != nil {
+		out.WriteString(ls.Value.String())
+	}
+
+	out.WriteString(";")
+
+	return out.String()
+}
+
 type ReturnStatement struct {
 	Token       token.Token // token.RETURN token
 	ReturnValue Expression
@@ -44,6 +74,35 @@ type ReturnStatement struct {
 func (rs *ReturnStatement) statementNode()       {}
 func (rs *ReturnStatement) TokenLiteral() string { return rs.Token.Literal }
 
+func (rs *ReturnStatement) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(rs.TokenLiteral() + " ")
+
+	if rs.ReturnValue != nil {
+		out.WriteString(rs.ReturnValue.String())
+	}
+
+	out.WriteString(";")
+
+	return out.String()
+}
+
+type ExpressionStatement struct {
+	Token      token.Token // the first token of the expression
+	Expression Expression
+}
+
+func (es *ExpressionStatement) statementNode()       {}
+func (es *ExpressionStatement) TokenLiteral() string { return es.Token.Literal }
+
+func (es *ExpressionStatement) String() string {
+	if es.Expression != nil {
+		return es.Expression.String()
+	}
+	return ""
+}
+
 type Identifier struct {
 	Token token.Token // token.IDENT token
 	Value string
@@ -51,3 +110,4 @@ type Identifier struct {
 
 func (i *Identifier) expressionNode()      {}
 func (i *Identifier) TokenLiteral() string { return i.Token.Literal }
+func (i *Identifier) String() string       { return i.Value }

--- a/밑바닥부터 만드는 인터프리터 in Go/src/monkey/ast/ast_test.go
+++ b/밑바닥부터 만드는 인터프리터 in Go/src/monkey/ast/ast_test.go
@@ -1,0 +1,28 @@
+package ast
+
+import (
+	"monkey/token"
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	program := &Program{
+		Statements: []Statement{
+			&LetStatement{
+				Token: token.Token{Type: token.LET, Literal: "let"},
+				Name: &Identifier{
+					Token: token.Token{Type: token.IDENT, Literal: "myVar"},
+					Value: "myVar",
+				},
+				Value: &Identifier{
+					Token: token.Token{Type: token.IDENT, Literal: "anotherVar"},
+					Value: "anotherVar",
+				},
+			},
+		},
+	}
+
+	if program.String() != "let myVar = anotherVar;" {
+		t.Errorf("program.String() wrong. got=%q", program.String())
+	}
+}


### PR DESCRIPTION
### TL;DR

Added string representation to AST nodes to enable better debugging and testing of the parser.

### What changed?

- Added a `String()` method to the `Node` interface
- Implemented `String()` for all existing AST node types:
  - `Program`
  - `LetStatement`
  - `ReturnStatement`
  - `Identifier`
- Added a new `ExpressionStatement` type with its implementation
- Added imports for `bytes` package to support string building
- Created a test file (`ast_test.go`) to verify string representation works correctly

### How to test?

Run the new test that verifies the string representation:

```
go test ./monkey/ast
```

The test checks that a program with a let statement correctly converts to the string "let myVar = anotherVar;".

### Why make this change?

String representation of AST nodes is essential for debugging the parser and for writing tests that verify the parser produces the expected AST. This implementation allows us to convert any AST node back to a string that resembles the original source code, making it easier to validate parsing results and inspect the AST structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- AST 노드의 문자열 변환 기능이 추가되어, 프로그램 구조를 소스 코드 형태의 문자열로 변환할 수 있습니다.
- **테스트**
	- AST의 문자열 변환 기능을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->