### PR TITLE
[밑바닥부터 만드는 인터프리터 in Go] 표현식 파싱: 식별자

### DIFF
--- a/밑바닥부터 만드는 인터프리터 in Go/src/monkey/parser/parser.go
+++ b/밑바닥부터 만드는 인터프리터 in Go/src/monkey/parser/parser.go
@@ -7,12 +7,31 @@ import (
 	"monkey/token"
 )
 
+const (
+	_ int = iota
+	LOWEST
+	EQUALS      // ==
+	LESSGREATER // > or <
+	SUM         // +
+	PRODUCT     // *
+	PREFIX      // -X or !X
+	CALL        // myFunction(X)
+)
+
+type (
+	prefixParseFn func() ast.Expression
+	infixParseFn  func(ast.Expression) ast.Expression
+)
+
 type Parser struct {
 	l      *lexer.Lexer
 	errors []string
 
 	curToken  token.Token
 	peekToken token.Token
+
+	prefixParseFns map[token.TokenType]prefixParseFn
+	infixParseFns  map[token.TokenType]infixParseFn
 }
 
 func New(l *lexer.Lexer) *Parser {
@@ -20,6 +39,9 @@ func New(l *lexer.Lexer) *Parser {
 		l:      l,
 		errors: []string{},
 	}
+
+	p.prefixParseFns = make(map[token.TokenType]prefixParseFn)
+	p.registerPrefix(token.IDENT, p.parseIdentifier)
 
 	// read two tokens so curToken and peekToken are both set
 	p.nextToken()
@@ -34,9 +56,7 @@ func (p *Parser) ParseProgram() *ast.Program {
 
 	for p.curToken.Type != token.EOF {
 		stmt := p.parseStatement()
-		if stmt != nil {
-			program.Statements = append(program.Statements, stmt)
-		}
+		program.Statements = append(program.Statements, stmt)
 		p.nextToken()
 	}
 
@@ -59,7 +79,7 @@ func (p *Parser) parseStatement() ast.Statement {
 	case token.RETURN:
 		return p.parseReturnStatement()
 	default:
-		return nil
+		return p.parseExpressionStatement()
 	}
 }
 
@@ -98,6 +118,31 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 	return stmt
 }
 
+func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
+	stmt := &ast.ExpressionStatement{Token: p.curToken}
+	stmt.Expression = p.parseExpression(LOWEST)
+
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return stmt
+}
+
+func (p *Parser) parseExpression(precedence int) ast.Expression {
+	prefix := p.prefixParseFns[p.curToken.Type]
+	if prefix == nil {
+		return nil
+	}
+	leftExp := prefix()
+
+	return leftExp
+}
+
+func (p *Parser) parseIdentifier() ast.Expression {
+	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+}
+
 func (p *Parser) curTokenIs(t token.TokenType) bool {
 	return p.curToken.Type == t
 }
@@ -120,4 +165,12 @@ func (p *Parser) peekError(t token.TokenType) {
 	msg := fmt.Sprintf("expected next token to be %s, got %s instead",
 		t, p.peekToken.Type)
 	p.errors = append(p.errors, msg)
+}
+
+func (p *Parser) registerPrefix(tokenType token.TokenType, fn prefixParseFn) {
+	p.prefixParseFns[tokenType] = fn
+}
+
+func (p *Parser) registerInfix(tokenType token.TokenType, fn infixParseFn) {
+	p.infixParseFns[tokenType] = fn
 }

--- a/밑바닥부터 만드는 인터프리터 in Go/src/monkey/parser/parser_test.go
+++ b/밑바닥부터 만드는 인터프리터 in Go/src/monkey/parser/parser_test.go
@@ -97,7 +97,7 @@ func TestIdentifierExpression(t *testing.T) {
 		t.Fatalf("exp not *ast.Identifier, got=%T", stmt.Expression)
 	}
 	if ident.Value != "foobar" {
-		t.Errorf("indent.Value not %s. got=%s", "foobar", ident.Value)
+		t.Errorf("ident.Value not %s. got=%s", "foobar", ident.Value)
 	}
 	if ident.TokenLiteral() != "foobar" {
 		t.Errorf("ident.TokenLiteral not %s. got=%s", "foobar",

--- a/밑바닥부터 만드는 인터프리터 in Go/src/monkey/parser/parser_test.go
+++ b/밑바닥부터 만드는 인터프리터 in Go/src/monkey/parser/parser_test.go
@@ -74,6 +74,37 @@ func TestReturnStatements(t *testing.T) {
 	}
 }
 
+func TestIdentifierExpression(t *testing.T) {
+	input := "foobar;"
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program has not enough statements. got=%d",
+			len(program.Statements))
+	}
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.ExpressionStatement. got=%T",
+			program.Statements[0])
+	}
+
+	ident, ok := stmt.Expression.(*ast.Identifier)
+	if !ok {
+		t.Fatalf("exp not *ast.Identifier, got=%T", stmt.Expression)
+	}
+	if ident.Value != "foobar" {
+		t.Errorf("indent.Value not %s. got=%s", "foobar", ident.Value)
+	}
+	if ident.TokenLiteral() != "foobar" {
+		t.Errorf("ident.TokenLiteral not %s. got=%s", "foobar",
+			ident.TokenLiteral())
+	}
+}
+
 func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
 	if s.TokenLiteral() != "let" {
 		t.Errorf("s.TokenLiteral not 'let'. got=%q", s.TokenLiteral())


### PR DESCRIPTION
### TL;DR

Implemented expression parsing with support for identifier expressions using Pratt parsing technique.

### What changed?

- Added precedence constants for operator precedence (LOWEST, EQUALS, LESSGREATER, etc.)
- Defined types for prefix and infix parse functions
- Extended Parser struct with maps for prefix and infix parse functions
- Implemented parseExpressionStatement and parseExpression methods
- Added parseIdentifier function to handle identifier expressions
- Added helper methods to register prefix and infix parse functions
- Initialized prefixParseFns map and registered identifier parsing function
- Modified parseStatement to handle expression statements

### How to test?

Run the new test case `TestIdentifierExpression` which verifies that:
- The parser correctly parses identifier expressions
- The parsed identifier has the correct value and token literal
- The expression statement is properly created

### Why make this change?

This change implements the foundation for expression parsing using Pratt parsing (top-down operator precedence parsing), which allows for efficient parsing of expressions with different precedence levels. Starting with identifier expressions provides the base for more complex expression types that will be built on top of this framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 식(Identifier) 파싱 기능이 추가되었습니다.
  - 연산자 우선순위와 접두어/중위 파싱 함수 등록 기능이 도입되었습니다.

- **테스트**
  - 식(Identifier) 파싱 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->